### PR TITLE
fix: メッセージエリアが入力フォームに重なって表示される問題を解消

### DIFF
--- a/src/pages/chatpage/GroupChatPage.jsx
+++ b/src/pages/chatpage/GroupChatPage.jsx
@@ -216,9 +216,11 @@ function GroupChatPage() {
       <Box
         sx={{
           bgcolor: '#EAEAEA',
-          minHeight: '100vh',
+          height: 'calc(100vh - 144px)',
           display: 'flex',
           flexDirection: 'column',
+          position: 'relative',
+          overflow: 'hidden',
         }}
       >
         {/* ヘッダー */}
@@ -277,9 +279,11 @@ function GroupChatPage() {
             flex: 1,
             overflowY: 'auto',
             p: 2,
-            mt: '136px',
-            mb: '200px',
+            mt: '88px',
+            mb: '75px',
             zIndex: 1,
+            height: 'calc(100vh - 280px)',
+            maxHeight: 'calc(100vh - 280px)',
           }}
         >
           {messages.map((message) => (
@@ -398,6 +402,7 @@ function GroupChatPage() {
             left: 0,
             right: 0,
             bgcolor: 'background.paper',
+            zIndex: 2,
           }}
         >
           <Paper


### PR DESCRIPTION
## 対応する Issue

<!-- 該当の Issue を Close したくない場合は、 `Closes` の文言を削除する。 -->
Closes #126 

## リンク

<!-- 参考にしたサイト等があれば記載する。 -->

## やったこと

- メッセージエリアが入力フォームに重なってしまう問題を解決した

## やらなかったこと

- 

## ユーザーへの影響

<!-- ユーザーから見て、できるようになったことやできなくなったこと等を記載する。 -->

## 動作確認

### 確認した環境

### 確認したこと
<!-- スクショや動画を貼っても良い。 -->

- 

### 確認しなかった（できなかった）こと

- 

## その他
